### PR TITLE
feat(adjust): Add trackThirdPartySharing and URL processability checks

### DIFF
--- a/tappRefEngineSDK/src/main/java/com/example/tapp/Tapp+Adjust.kt
+++ b/tappRefEngineSDK/src/main/java/com/example/tapp/Tapp+Adjust.kt
@@ -1,10 +1,17 @@
 package com.example.tapp
+
+import android.content.Context
 import com.adjust.sdk.AdjustPurchaseVerificationResult
+import com.adjust.sdk.AdjustThirdPartySharing
 import com.example.tapp.services.affiliate.adjust.AdjustAffiliateService
 import com.example.tapp.utils.Logger
 
+val Tapp.context: Context
+    get() = dependencies.context
+
 fun Tapp.adjustTrackAdRevenue(source: String, revenue: Double, currency: String) {
-    getAdjustService()?.trackAdRevenue(source, revenue, currency) ?: Logger.logError("Adjust service not available.")
+    getAdjustService()?.trackAdRevenue(source, revenue, currency)
+        ?: Logger.logError("Adjust service not available.")
 }
 
 fun Tapp.adjustVerifyAppStorePurchase(
@@ -16,18 +23,34 @@ fun Tapp.adjustVerifyAppStorePurchase(
         ?: Logger.logError("Adjust service not available.")
 }
 
-
-
 fun Tapp.adjustSetPushToken(token: String) {
-    getAdjustService()?.setPushToken(token) ?: Logger.logError("Adjust service not available.")
+    getAdjustService()?.setPushToken(token)
+        ?: Logger.logError("Adjust service not available.")
+}
+
+fun Tapp.adjustGdprForgetMe() {
+    getAdjustService()?.gdprForgetMe(context)
+        ?: Logger.logError("Adjust service not available.")
+}
+
+fun Tapp.adjustTrackThirdPartySharing(isEnabled: Boolean) {
+    getAdjustService()?.trackThirdPartySharing(isEnabled)
+        ?: Logger.logError("Adjust service not available.")
+}
+
+fun Tapp.getAdjustAttribution(completion: (com.adjust.sdk.AdjustAttribution?) -> Unit) {
+    getAdjustService()?.getAdjustAttribution(completion)
+        ?: Logger.logError("Adjust service not available.")
 }
 
 fun Tapp.adjustGetAdid(completion: (String?) -> Unit) {
-    getAdjustService()?.getAdid(completion) ?: Logger.logError("Adjust service not available.")
+    getAdjustService()?.getAdid(completion)
+        ?: Logger.logError("Adjust service not available.")
 }
 
 fun Tapp.adjustGetIdfa(completion: (String?) -> Unit) {
-    getAdjustService()?.getAdvertisingId(completion) ?: Logger.logError("Adjust service not available.")
+    getAdjustService()?.getAdvertisingId(completion)
+        ?: Logger.logError("Adjust service not available.")
 }
 
 // Utility to retrieve AdjustAffiliateService

--- a/tappRefEngineSDK/src/main/java/com/example/tapp/Tapp.kt
+++ b/tappRefEngineSDK/src/main/java/com/example/tapp/Tapp.kt
@@ -114,6 +114,12 @@ class Tapp(context: Context) {
             return
         }
 
+        if (!shouldProcess(url)) {
+            Logger.logInfo("URL is not processable. Skipping processing.")
+            completion?.invoke(Result.success(Unit))
+            return
+        }
+
         // Step 3: Continue to the next logic
         appWillOpen(parsedUri, completion)
     }
@@ -181,7 +187,6 @@ class Tapp(context: Context) {
     fun shouldProcess(url: String?):Boolean {
         if(url == null) return false
         Logger.logInfo("ShouldProcess() started!")
-        Logger.logError("ShouldProcess(): url is null")
         val tappService =
             dependencies.affiliateServiceFactory.getAffiliateService(Affiliate.TAPP, dependencies)
         if (tappService !is TappAffiliateService) {

--- a/tappRefEngineSDK/src/main/java/com/example/tapp/TappExtensions.kt
+++ b/tappRefEngineSDK/src/main/java/com/example/tapp/TappExtensions.kt
@@ -70,7 +70,7 @@ internal fun Tapp.handleReferralCallback(
             onSuccess = { tappUrlResponse ->
                 Logger.logInfo("handleImpression success: $tappUrlResponse")
 
-                // (Optional) Extract parameters from the URL
+                //TODO:: MAKE IT FOR ALL THE MMPS
                 val linkToken = url.getQueryParameter("adj_t")
                 if (linkToken != null) {
                     Logger.logInfo("Extracted linkToken: $linkToken")

--- a/tappRefEngineSDK/src/main/java/com/example/tapp/services/affiliate/adjust/AdjustAffiliateService.kt
+++ b/tappRefEngineSDK/src/main/java/com/example/tapp/services/affiliate/adjust/AdjustAffiliateService.kt
@@ -1,8 +1,10 @@
 package com.example.tapp.services.affiliate.adjust
 
+import android.content.Context
 import android.net.Uri
 import com.adjust.sdk.Adjust
 import com.adjust.sdk.AdjustAdRevenue
+import com.adjust.sdk.AdjustAttribution
 import com.adjust.sdk.AdjustConfig
 import com.adjust.sdk.AdjustDeeplink
 import com.adjust.sdk.AdjustEvent
@@ -18,6 +20,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+
 
 internal class AdjustAffiliateService(private val dependencies: Dependencies) : AffiliateService {
     private var isAdjustEnabled: Boolean = false
@@ -117,6 +120,28 @@ internal class AdjustAffiliateService(private val dependencies: Dependencies) : 
             }
             completion(adid)
         }
+    }
+
+    fun gdprForgetMe(context: Context?) {
+        Adjust.gdprForgetMe(context);
+        Logger.logInfo("Adjust gdprForgetMe run")
+    }
+
+    fun trackThirdPartySharing(isEnabled: Boolean) {
+        // Construct the AdjustThirdPartySharing object based on the boolean value.
+        // This is an example. Adjust the implementation as needed.
+        val thirdPartySharing = com.adjust.sdk.AdjustThirdPartySharing(isEnabled)
+        Adjust.trackThirdPartySharing(thirdPartySharing)
+        Logger.logInfo("Adjust trackThirdPartySharing run with isEnabled: $isEnabled")
+    }
+
+
+    fun getAdjustAttribution(completion: (com.adjust.sdk.AdjustAttribution?) -> Unit) {
+        Adjust.getAttribution { attribution ->
+            Logger.logInfo("Attribution received: $attribution")
+            completion(attribution)
+        }
+        Logger.logInfo("Adjust getAttribution run")
     }
 
     fun getAdvertisingId(completion: (String?) -> Unit) {

--- a/tappRefEngineSDK/src/main/java/com/example/tapp/services/affiliate/tapp/TappAffiliateService.kt
+++ b/tappRefEngineSDK/src/main/java/com/example/tapp/services/affiliate/tapp/TappAffiliateService.kt
@@ -175,7 +175,6 @@ internal class TappAffiliateService(private val dependencies: Dependencies) : Af
 
     fun shouldProcess(url: Uri): Boolean {
         val config = dependencies.keystoreUtils.getConfig() ?: return false
-        Logger.logError("Affiliate is missing")
 
         return when (config.affiliate) {
             Affiliate.ADJUST -> url.param(AdjustURLParamKey.TOKEN.value) != null


### PR DESCRIPTION
- Implemented trackThirdPartySharing in AdjustAffiliateService to call Adjust.trackThirdPartySharing with a constructed parameter.
- Updated Tapp extension to expose adjustTrackThirdPartySharing via the service.
- Added URL processability checks in appWillOpenInt and appWillOpen methods using shouldProcess.
- Enhanced logging for attribution, deep links, and event handling.