### PR TITLE
fix(event): Serialize custom EventAction correctly

### DIFF
--- a/tappRefEngineSDK/src/main/java/com/example/tapp/services/network/RequestModels.kt
+++ b/tappRefEngineSDK/src/main/java/com/example/tapp/services/network/RequestModels.kt
@@ -118,7 +118,9 @@ class RequestModels {
         data object tapp_select_content : EventAction(38)
         data object tapp_begin_tutorial : EventAction(39)
         data object tapp_complete_tutorial : EventAction(40)
-        data class custom(val customValue: String) : EventAction(0)
+        data class custom(val customValue: String) : EventAction(0) {
+            override fun toString(): String = customValue
+        }
 
         // Determine if the action is custom
         val isCustom: Boolean

--- a/tappRefEngineSDK/src/main/java/com/example/tapp/services/network/TappEndpoint.kt
+++ b/tappRefEngineSDK/src/main/java/com/example/tapp/services/network/TappEndpoint.kt
@@ -110,6 +110,12 @@ internal object TappEndpoint {
         val config = dependencies.keystoreUtils.getConfig()
             ?: throw TappError.MissingConfiguration("Configuration is missing")
 
+        val eventNameString = if (eventRequest.eventName.isCustom) {
+            (eventRequest.eventName as RequestModels.EventAction.custom).customValue
+        } else {
+            eventRequest.eventName.toString()
+        }
+
         val url = "${getBaseUrl(config.env.environmentName())}event"
         val headers = mapOf(
             "Content-Type" to "application/json",
@@ -119,9 +125,9 @@ internal object TappEndpoint {
         val body = mapOf(
             "tapp_token" to config.tappToken,
             "bundle_id" to (config.bundleID?:""),
-            "event_name" to eventRequest.eventName,
+            "event_name" to eventNameString,
             "event_url" to (config.deepLinkUrl?:""),
-        ).filterValues { it != null } // Remove null entries
+        ).filterValues { it != null }
 
         return RequestModels.Endpoint(url, headers, body)
     }


### PR DESCRIPTION
Custom events were being serialized using the default data class toString(), resulting in a value like "custom(customValue=w2w_get_suggestion)". Override toString() in the custom EventAction (or adjust the request builder) to return only the custom value, so that "w2w_get_suggestion" is sent as the event_name in the request body.